### PR TITLE
fixes issue with matplotlib=3.10 handles reversed list generator

### DIFF
--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -532,7 +532,7 @@ class UpSet:
         handles, labels = ax.get_legend_handles_labels()
         if self._horizontal:
             # Make legend order match visual stack order
-            ax.legend(reversed(handles), reversed(labels))
+            ax.legend(list(reversed(handles)), list(reversed(labels)))
         else:
             ax.legend()
 

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -792,10 +792,14 @@ class UpSet:
                 }
             )
         )
-        styles["linewidth"].fillna(1, inplace=True)
-        styles["facecolor"].fillna(self._facecolor, inplace=True)
-        styles["edgecolor"].fillna(styles["facecolor"], inplace=True)
-        styles["linestyle"].fillna("solid", inplace=True)
+        styles.fillna({
+            "linewidth": 1,
+            "facecolor": self._facecolor,
+            "edgecolor": styles["facecolor"],
+            "linestyle": "solid"
+            }, 
+            inplace=True
+        )
         del styles["hatch"]  # not supported in matrix (currently)
 
         x = np.repeat(np.arange(len(data)), n_cats)


### PR DESCRIPTION
It fixes an issue with Matplotlib 3.10, where the reversed function produces a generator instead of a list.
The solution is straight forward, call a list on the reversed generator.